### PR TITLE
Needed for poti to be an Aky submodule

### DIFF
--- a/include/poti.h
+++ b/include/poti.h
@@ -97,9 +97,11 @@ void poti_AddVariable (double timestamp, const char *container, const char *type
 void poti_SubVariable (double timestamp, const char *container, const char *type, double value);
 void poti_SetState (double timestamp, const char *container, const char *type, const char *value);
 void poti_PushState (double timestamp, const char *container, const char *type, const char *value);
+void poti_PushStateMark (double timestamp, const char *container, const char *type, const char *value, const char *mark);
 void poti_PopState (double timestamp, const char *container, const char *type);
 void poti_ResetState (double timestamp, const char *container, const char *type);
 void poti_StartLink (double timestamp, const char *container, const char *type, const char *sourceContainer, const char *value, const char *key);
+void poti_StartLinkSizeMark (double timestamp, const char *container, const char *type, const char *sourceContainer, const char *value, const char *key, const char *size, const char *mark);
 void poti_EndLink (double timestamp, const char *container, const char *type, const char *endContainer, const char *value, const char *key);
 void poti_NewEvent (double timestamp, const char *container, const char *type, const char *value);
 
@@ -119,12 +121,13 @@ void poti_UAddVariable (const int unique, double timestamp, const char *containe
 void poti_USubVariable (const int unique, double timestamp, const char *container, const char *type, double value, int extra, ...);
 void poti_USetState (const int unique, double timestamp, const char *container, const char *type, const char *value, int extra, ...);
 void poti_UPushState (const int unique, double timestamp, const char *container, const char *type, const char *value, int extra, ...);
+void poti_UPushState (const int unique, double timestamp, const char *container, const char *type, const char *value, int extra, ...);
 void poti_UPopState (const int unique, double timestamp, const char *container, const char *type, int extra, ...);
 void poti_UResetState (const int unique, double timestamp, const char *container, const char *type, int extra, ...);
 void poti_UStartLink (const int unique, double timestamp, const char *container, const char *type, const char *sourceContainer, const char *value, const char *key, int extra, ...);
 void poti_UEndLink (const int unique, double timestamp, const char *container, const char *type, const char *endContainer, const char *value, const char *key, int extra, ...);
 void poti_UNewEvent (const int unique, double timestamp, const char *container, const char *type, const char *value, int extra, ...);
-  
+
 /*
  * Unalised API: without alias parameters
  */

--- a/src/poti_events.c
+++ b/src/poti_events.c
@@ -90,6 +90,11 @@ void poti_PushState (double timestamp, const char *container, const char *type, 
   poti_UPushState (identifiers[PAJE_PushState], timestamp, container, type, value, 0);
 }
 
+void poti_PushStateMark (double timestamp, const char *container, const char *type, const char *value, const char *mark)
+{
+  poti_UPushState (identifiers[PAJE_PushState], timestamp, container, type, value, 1, mark);
+}
+
 void poti_PopState (double timestamp, const char *container, const char *type)
 {
   poti_UPopState (identifiers[PAJE_PopState], timestamp, container, type, 0);
@@ -103,6 +108,11 @@ void poti_ResetState (double timestamp, const char *container, const char *type)
 void poti_StartLink (double timestamp, const char *container, const char *type, const char *sourceContainer, const char *value, const char *key)
 {
   poti_UStartLink (identifiers[PAJE_StartLink], timestamp, container, type, sourceContainer, value, key, 0);
+}
+
+void poti_StartLinkSizeMark (double timestamp, const char *container, const char *type, const char *sourceContainer, const char *value, const char *key, const char *size, const char *mark)
+{
+  poti_UStartLink (identifiers[PAJE_StartLink], timestamp, container, type, sourceContainer, value, key, 2, size, mark);
 }
 
 void poti_EndLink (double timestamp, const char *container, const char *type, const char *endContainer, const char *value, const char *key)


### PR DESCRIPTION
These additions are only required in the latest version of Akypuera with support for some collective communications. 