### PR TITLE
Fallback if .git or git(1) is not available re. reproducible build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,8 +17,8 @@ PROJECT(poti)
 SET(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
 enable_testing()
 
-EXEC_PROGRAM("git --git-dir=${PROJECT_SOURCE_DIR}/.git log --oneline -1" OUTPUT_VARIABLE "POTI_GITVERSION")
-EXEC_PROGRAM("git --git-dir=${PROJECT_SOURCE_DIR}/.git log -n 1 --format=%ai" OUTPUT_VARIABLE "POTI_GITDATE")
+EXEC_PROGRAM("git --git-dir=${PROJECT_SOURCE_DIR}/.git log --oneline -1 2>/dev/null || echo '(unknown)'" OUTPUT_VARIABLE "POTI_GITVERSION")
+EXEC_PROGRAM("git --git-dir=${PROJECT_SOURCE_DIR}/.git log -n 1 --format=%ai 2>/dev/null || echo '(unknown)'" OUTPUT_VARIABLE "POTI_GITDATE")
 
 SET(CMAKE_C_FLAGS "-std=c11 -Wall -Wextra -Wpedantic -Wmissing-prototypes -Wmissing-declarations -Wwrite-strings -Wno-unused-function -Wno-unused-parameter -Wno-strict-aliasing -Wno-format-nonliteral -Werror ")
 


### PR DESCRIPTION
Whilst working on the Reproducible Builds effort [0], we noticed
that poti could not be built reproducibly.

This is due to missing .git/ directory, but we might as well make
this fallback nicely if Git itself is not available either.

 [0] https://reproducible-builds.org/

Signed-off-by: Chris Lamb <chris@chris-lamb.co.uk>